### PR TITLE
fix: copy response into reply

### DIFF
--- a/modsecurity.go
+++ b/modsecurity.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"time"
@@ -84,7 +85,16 @@ func (a *Modsecurity) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		resp.Write(rw)
+		// copy headers
+		for k, vv := range resp.Header {
+			for _, v := range vv {
+				rw.Header().Set(k, v)
+			}
+		}
+		// copy status
+		rw.WriteHeader(resp.StatusCode)
+		// copy body
+		io.Copy(rw, resp.Body)
 		return
 	}
 


### PR DESCRIPTION
Right now, the plugin send back the whole response in the body from Modsec, not only the response body.
We are seeing other stuff like headers in the body.

```
HTTP/1.1 404 Not Found
Content-Length: 13238
Connection: keep-alive
Content-Type: text/html
Date: Thu, 30 Dec 2021 14:32:50 GMT
Etag: "613f2f21-33b6"
Server: nginx

<!DOCTYPE html>
<html lang="en">
```

With this fix we copy the headers, status and body to the response.
That way we can have the real Modsec reponse in the browser (body+headers+status).

Example for me:
![image](https://user-images.githubusercontent.com/6797195/147762402-37567a7c-0eb6-4560-9fec-42b7e09c09e9.png)

VS 

![image](https://user-images.githubusercontent.com/6797195/147762302-19b366e4-98fe-461e-aef7-7b3694d53a6b.png)


