### PR TITLE
Limit body buffering to avoid resource exhaustion

### DIFF
--- a/.traefik.yml
+++ b/.traefik.yml
@@ -7,6 +7,7 @@ summary: 'Traefik plugin to proxy requests to owasp/modsecurity-crs:apache'
 
 testData:
   ModsecurityUrl: http://waf:80
+  MaxBodySize: 10485760
 
 iconPath: ./img/icon.png
 bannerPath: ./img/banner.png

--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ If it is > 400, then the error page is returned instead.
 
 The *dummy* service is created so the waf container forward the request to a service and respond with 200 OK all the time.
 
+## Configuration
+
+This plugin supports these configuration:
+
+* `modSecurityUrl`: (**mandatory**) it's the URL for the owasp/modsecurity container.
+* `maxBodySize`: (optional) it's the maximum limit for requests body size. Requests exceeding this value will be rejected using `HTTP 413 Request Entity Too Large`.
+  The default value for this parameter is 10MB. Zero means "use default value".
+
+**Note**: body of every request will be buffered in memory while the request is in-flight (i.e.: during the security check and during the request processing by traefik and the backend), so you may want to tune `maxBodySize` depending on how much RAM you have.
 
 ## Local development (docker-compose.local.yml)
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -22,6 +22,7 @@ services:
       - traefik.enable=true
       - traefik.http.services.traefik.loadbalancer.server.port=8080
       - traefik.http.middlewares.waf.plugin.traefik-modsecurity-plugin.modSecurityUrl=http://waf:80
+      - traefik.http.middlewares.waf.plugin.traefik-modsecurity-plugin.maxBodySize=10485760
 
   waf:
     image: owasp/modsecurity-crs:apache

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - traefik.enable=true
       - traefik.http.services.traefik.loadbalancer.server.port=8080
       - traefik.http.middlewares.waf.plugin.traefik-modsecurity-plugin.modSecurityUrl=http://waf:80
+      - traefik.http.middlewares.waf.plugin.traefik-modsecurity-plugin.maxBodySize=10485760
 
   waf:
     image: owasp/modsecurity-crs:apache


### PR DESCRIPTION
This PR implement a limit for body buffering in order to avoid resource exhaustion using a very large body (see #7). The default limit is 10MB (which should be enough for non-uploads requests), but it's configurable.