### PR TITLE
Add support for configurable timeout

### DIFF
--- a/modsecurity_test.go
+++ b/modsecurity_test.go
@@ -129,6 +129,7 @@ func TestModsecurity_ServeHTTP(t *testing.T) {
 				modSecurityUrl: modsecurityMockServer.URL,
 				maxBodySize:    1024,
 				name:           "modsecurity-middleware",
+				httpClient:     http.DefaultClient,
 				logger:         log.New(io.Discard, "", log.LstdFlags),
 			}
 


### PR DESCRIPTION
Hi, I have some use cases where the backend responds in several seconds (e.g. it is building a zip file).

This PR allows to set a timeout in the config and uses it instead of the hardcoded value of 2 seconds.