### PR TITLE
Update waf url

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   traefik:
-    image: traefik
+    image: traefik:3.0.1
     ports:
       - "8000:80"
       - "8080:8080"
@@ -22,7 +22,7 @@ services:
       - traefik.http.middlewares.waf.plugin.traefik-modsecurity-plugin.maxBodySize=10485760
 
   waf:
-    image: owasp/modsecurity-crs:apache
+    image: owasp/modsecurity-crs:4.2.0-apache-202405220605
     environment:
       - PARANOIA=1
       - ANOMALY_INBOUND=10

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -18,7 +18,7 @@ services:
     labels:
       - traefik.enable=true
       - traefik.http.services.traefik.loadbalancer.server.port=8080
-      - traefik.http.middlewares.waf.plugin.traefik-modsecurity-plugin.modSecurityUrl=http://waf:80
+      - traefik.http.middlewares.waf.plugin.traefik-modsecurity-plugin.modSecurityUrl=http://waf:8080
       - traefik.http.middlewares.waf.plugin.traefik-modsecurity-plugin.maxBodySize=10485760
 
   waf:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   traefik:
-    image: traefik
+    image: traefik:3.0.1
     ports:
       - "8000:80"
       - "8080:8080"
@@ -22,7 +22,7 @@ services:
       - traefik.http.middlewares.waf.plugin.traefik-modsecurity-plugin.maxBodySize=10485760
 
   waf:
-    image: owasp/modsecurity-crs:apache
+    image: owasp/modsecurity-crs:4.2.0-apache-202405220605
     environment:
       - PARANOIA=1
       - ANOMALY_INBOUND=10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     labels:
       - traefik.enable=true
       - traefik.http.services.traefik.loadbalancer.server.port=8080
-      - traefik.http.middlewares.waf.plugin.traefik-modsecurity-plugin.modSecurityUrl=http://waf:80
+      - traefik.http.middlewares.waf.plugin.traefik-modsecurity-plugin.modSecurityUrl=http://waf:8080
       - traefik.http.middlewares.waf.plugin.traefik-modsecurity-plugin.maxBodySize=10485760
 
   waf:


### PR DESCRIPTION
I just came across this project for the first time.  I had some issues getting set up and a little digging through the [this repo](https://github.com/coreruleset/modsecurity-crs-docker?tab=readme-ov-file) I noticed that the `waf` container is now listening on port 8080 by default.  This PR seeks to update the `docker-compose.yml` file with the new and correct value.