### PR TITLE
README.md: fix semi-dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Demo with WAF intercepting relative access in query param.
 
 ## Usage (docker-compose.yml)
 
-See [docker-compose.yml](docker-compose.yml)
+See [docker-compose.yml](https://github.com/acouvreur/traefik-modsecurity-plugin/blob/main/docker-compose.yml)
 
 1. docker-compose up
 2. Go to http://localhost:8000/website, the request is received without warnings


### PR DESCRIPTION
The link to the docker-compose.yml isn't working on [the traefik plugin page](https://plugins.traefik.io/plugins/628c9eadffc0cd18356a9799/modsecurity-plugin). It's leading to the same plugin page and thus slightly confusing to the unknown users. Making it full qualified solves this problem.