### PR TITLE
Use traefik/whoami to replace deprecated image

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -30,10 +30,10 @@ services:
       - BACKEND=http://dummy
 
   dummy:
-    image: containous/whoami
+    image: traefik/whoami
 
   website:
-    image: containous/whoami
+    image: traefik/whoami
     labels:
       - traefik.enable=true
       - traefik.http.routers.website.rule=PathPrefix(`/website`)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,10 +30,10 @@ services:
       - BACKEND=http://dummy
 
   dummy:
-    image: containous/whoami
+    image: traefik/whoami
 
   website:
-    image: containous/whoami
+    image: traefik/whoami
     labels:
       - traefik.enable=true
       - traefik.http.routers.website.rule=PathPrefix(`/website`)


### PR DESCRIPTION
Replaces `containous/whoami` with `traefik/whoami`

Fixes #18, #19 and #25 